### PR TITLE
Automate tag-based Maven Central releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish to Maven Central
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: maven-central-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Java and Maven Central credentials
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          server-id: ossrh
+          server-username-env-var: MAVEN_CENTRAL_USERNAME
+          server-password-env-var: MAVEN_CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase-env-var: MAVEN_GPG_PASSPHRASE
+
+      - name: Verify tag matches POM version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF_NAME#v}"
+          pom_version="$(mvn --batch-mode --no-transfer-progress help:evaluate -Dexpression=project.version -q -DforceStdout)"
+          if [[ "$tag_version" != "$pom_version" ]]; then
+            echo "Tag version $tag_version does not match POM version $pom_version" >&2
+            exit 1
+          fi
+
+      - name: Publish signed artifacts
+        run: mvn --batch-mode --no-transfer-progress deploy -Possrh -DskipTests
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}


### PR DESCRIPTION
## Summary

- add a Maven Central publishing workflow triggered only by `v*` tags
- require the tag version to match `project.version` before deployment
- import signing and Central credentials from GitHub Actions Secrets
- prevent concurrent publication attempts for the same tag

## Validation

- parsed the workflow as YAML
- confirmed the referenced checkout and setup-java major tags exist
- verified the parent release profile produces a valid GPG signature

No release tag is included in this PR. Maven Central versions are immutable, so the workflow starts with a future version.
